### PR TITLE
stats credits fixes

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
         "beampalette",
         "behaviour",
         "callout",
+        "Christodoulos",
         "colorpalette",
         "colourizes",
         "controlsys",
@@ -44,6 +45,7 @@
         "multicolour",
         "multicoloured",
         "mysidebar",
+        "Navgoco",
         "noedit",
         "noprinter",
         "offleft",
@@ -74,6 +76,7 @@
         "Submasters",
         "taglogic",
         "techwiki",
+        "Tsoulloftas",
         "woah"
     ],
     "ignorePaths": [

--- a/docs/_data/sidebars/Overview_sidebar.yml
+++ b/docs/_data/sidebars/Overview_sidebar.yml
@@ -61,7 +61,7 @@ entries:
       output: web, pdf
       type: homepage
 
-    - title: Stats and Credits
+    - title: Stats, Credits and Licenses 
       url: /stats_credits.html
       output: web, pdf
       

--- a/docs/licenses/txt/documentation.txt
+++ b/docs/licenses/txt/documentation.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Tom Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/licenses/txt/eps.txt
+++ b/docs/licenses/txt/eps.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 E.P. Scarlett Technical Theatre Crew and Society
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/licenses/txt/navgoco.txt
+++ b/docs/licenses/txt/navgoco.txt
@@ -1,0 +1,27 @@
+/* This license pertains to the Navgoco jQuery component used for the sidebar. */
+
+Copyright (c) 2013, Christodoulos Tsoulloftas, http://www.komposta.net
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+   * Neither the name of the <Christodoulos Tsoulloftas> nor the names of its
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/stats credits license.md
+++ b/docs/stats credits license.md
@@ -1,5 +1,5 @@
 ---
-title: Stats and Credits
+title: Stats, Credits and Licenses
 sidebar: Overview_sidebar
 permalink: stats_credits.html
 # draft: true
@@ -10,7 +10,6 @@ permalink: stats_credits.html
 # last_updated: Month Day, Year
 # tags: []
 noedit: true
-noprinter: true
 customPageType: info
 ---
 
@@ -22,7 +21,7 @@ customPageType: info
     {% assign word_count = word_count | plus:words %}
 {% endfor %}
 
-Currently, there are **{{valid_pages | size}}** active pages in the wiki averaging roughly **{{word_count | divided_by:valid_pages.size}}** words per page. **{{valid_pages | where_exp:"item","item.authors" | size}}** pages have a non-anonymous author.
+Currently, there are **{{valid_pages | size}}** active pages in the wiki, averaging roughly **{{word_count | divided_by:valid_pages.size}}** words per page. **{{valid_pages | where_exp:"item","item.authors" | where_exp:"item","item.authors.size > 0" | size}}** pages have a non-anonymous author.
 
 <!-- Data for credits and percentage bars -->
 {% assign highest_contribution = 0 %}
@@ -34,15 +33,13 @@ Currently, there are **{{valid_pages | size}}** active pages in the wiki averagi
     {% endif %}
 {% endfor %}
 
-{% assign highest_up_10 = highest_contribution | times:10 %}
-
 The following individuals have chosen to take credit for their work. They are listed in alphabetical order:
 <table class="credit-table">
     <thead>
         <tr>
             <th>Names</th>
             <th>Contributions</th>
-            <th>Percentage</th>
+            <th>Visual Contribution</th>
         </tr>
     </thead>
 <tbody>
@@ -60,11 +57,24 @@ The following individuals have chosen to take credit for their work. They are li
         <td>
         Contributed to {{page_count}} page{% if page_count != 1 %}s{% endif %}
         </td>
-        {% assign percent_contribution = page_count | times:10 | divided_by:highest_contribution %}
         <td>
         <div class="stats-contribution-wrapper">
+        {% assign filled_circles = 0 %}
+        {% assign empty_circles = 10 %}
+
+        {% assign current_check = highest_contribution %}
+        
         {% for i in (1..10) %}
-            {% if i <= percent_contribution %}
+            {% if page_count >= current_check %}
+                {% assign filled_circles = filled_circles | plus:1 %}
+                {% assign empty_circles = empty_circles | minus:1 %}            
+            {% endif %}
+
+            {% assign current_check = current_check | divided_by:2.0 %}
+        {% endfor %}
+
+        {% for i in (1..10) %}
+            {% if i <= filled_circles %}
                 <i class="fa fa-circle stats-contribution sc-filled"></i>
             {% else %}
                 <i class="fa fa-circle stats-contribution sc-empty"></i>
@@ -75,7 +85,19 @@ The following individuals have chosen to take credit for their work. They are li
     {% endif %}
 {% endfor %}
 
+
 </tbody>
 </table>
 
 Many others have chosen to remain anonymous and have helped significantly in the background, even if they didn't directly write a page. I would personally like to thank everyone who has taken an interest in the project.
+
+<br><br><br><br>
+The wiki backend was created in part using the open-source [Documentation Theme for Jekyll](https://idratherbewriting.com/documentation-theme-jekyll/) created by [Tom Johnson](https://github.com/tomjoht).
+
+All licenses for this project can be found below:
+
+| License | Copyright Holder |
+|---------|------------------|
+| [E.P Scarlett Wiki](licenses/txt/eps.txt)  [(Alt)](https://github.com/epstechtheatre/epstechtheatre.github.io/blob/main/LICENSE) | E.P. Scarlett Technical Theatre Crew and Society |
+| [Documentation Theme](licenses/txt/documentation.txt) | Tom Johnson |
+| [Navgoco Sidebar](licenses/txt/navgoco.txt) | Christodoulos Tsoulloftas |


### PR DESCRIPTION
fix incorrect authored page count

add readable license and credit to source

update page title

## Describe Your Changes
- I modified existing content

## Provide any additional information:
- Update page title to `Stats, Credits and Licenses`
- Fix page count for authored pages
- Updated visual contribution math to be more liberal with allocating circles (math is now `highest contribution / 2 / 2 ...` where each division is the minimum required pages to receive that circle
- Add license notices to page, including to original project