### PR TITLE
fix: Encoder Wheel 404 on Keyboard Button Directory

### DIFF
--- a/docs/json/svg_button_url_dict.js
+++ b/docs/json/svg_button_url_dict.js
@@ -308,7 +308,7 @@ var buttonURLDict = [
         names: ["numbers", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
     },
     {
-        url: "/Lighting_keyboard_encoder_wheels.html",
+        url: "/Lighting_keyboard_encoderwheels.html",
         names: ["encoders", "encoder1", "encoder2", "encoder3", "encoder4"]
     },
     {


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
changes `encoder_wheels` to `encoderwheels` in the link dictionary

closes #105 