### PR TITLE
fix: Keyboard Directory Typos

### DIFF
--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/Shift.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/Shift.md
@@ -16,7 +16,7 @@ last_updated: August 19, 2021
 Like Shift on a keyboard, {% include console_button.html content="Shift" %} on the lighting board changes the action of some keys to similar, but alternative functions.
 ## Examples
 - [Using Shift with Clear](./Lighting_keyboard_clear.html)
-- [Using Shift with Encoder Pages](./Lighting_keyboard_encoder_pages.html)
+- [Using Shift with Encoder Pages](./Lighting_keyboard_encoderpages.html)
 - [Quickly Saving the Showfile](./Lighting_keyboard_update.html)
 
 ## On Keyboard

--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s1.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s1.md
@@ -12,9 +12,9 @@ toc: false
 # tags: []
 ---
 
-The key you click (Intensity / S1) has to very different usages. Please select which key you are looking for help with:
+The key you click (Intensity / S1) has two very different usages. Please select which key you are looking for help with:
 
 [Softkeys (S1)](./Lighting_keyboard_softkeys.html)
 
 
-[Intensity](./Lighting_keyboard_encoder_pages.html)
+[Intensity](./Lighting_keyboard_encoderpages.html)

--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s2.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s2.md
@@ -12,8 +12,8 @@ toc: false
 # tags: []
 ---
 
-The key you click (Focus / S2) has to very different usages. Please select which key you are looking for help with:
+The key you click (Focus / S2) has two very different usages. Please select which key you are looking for help with:
 
 [Softkeys (S2)](./Lighting_keyboard_softkeys.html)
 
-[Focus](./Lighting_keyboard_encoder_pages.html)
+[Focus](./Lighting_keyboard_encoderpages.html)

--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s3.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s3.md
@@ -12,8 +12,8 @@ toc: false
 # tags: []
 ---
 
-The key you click (Focus / S3) has to very different usages. Please select which key you are looking for help with:
+The key you click (Focus / S3) has two very different usages. Please select which key you are looking for help with:
 
 [Softkeys (S3)](./Lighting_keyboard_softkeys.html)
 
-[Color](./Lighting_keyboard_encoder_pages.html)
+[Color](./Lighting_keyboard_encoderpages.html)

--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s4.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s4.md
@@ -12,8 +12,8 @@ toc: false
 # tags: []
 ---
 
-The key you click (Shutter / S4) has to very different usages. Please select which key you are looking for help with:
+The key you click (Shutter / S4) has two very different usages. Please select which key you are looking for help with:
 
 [Softkeys (S4)](./Lighting_keyboard_softkeys.html)
 
-[Shutter](./Lighting_keyboard_encoder_pages.html)
+[Shutter](./Lighting_keyboard_encoderpages.html)

--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s5.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s5.md
@@ -12,8 +12,8 @@ toc: false
 # tags: []
 ---
 
-The key you click (Beam / S5) has to very different usages. Please select which key you are looking for help with:
+The key you click (Beam / S5) has two very different usages. Please select which key you are looking for help with:
 
 [Softkeys (S5)](./Lighting_keyboard_softkeys.html)
 
-[Image](./Lighting_keyboard_encoder_pages.html)
+[Image](./Lighting_keyboard_encoderpages.html)

--- a/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s6.md
+++ b/docs/pages/Lighting/Tutorials/Keyboard Buttons/disambiguation/s6.md
@@ -12,8 +12,8 @@ toc: false
 # tags: []
 ---
 
-The key you click (Form / S6) has to very different usages. Please select which key you are looking for help with:
+The key you click (Form / S6) has two very different usages. Please select which key you are looking for help with:
 
 [Softkeys (S6)](./Lighting_keyboard_softkeys.html)
 
-[Form](./Lighting_keyboard_encoder_pages.html)
+[Form](./Lighting_keyboard_encoderpages.html)


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
`to` --> `two`
`encoder_pages` --> `encoderpages`