### PR TITLE
fix: Headers are clickable on their entire line rather than just on text

### DIFF
--- a/docs/css/pageElements/headers.css
+++ b/docs/css/pageElements/headers.css
@@ -7,6 +7,7 @@ h5[id],
 h6[id],
 dt[id]{
 margin-top: 40px;
+display: inline-block;
 }
 
 h2  {


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
Changed header display mode to `display: inline-block`