### PR TITLE
fix: page title wrapping and spacing on small screen width

### DIFF
--- a/docs/css/pageElements/headers.css
+++ b/docs/css/pageElements/headers.css
@@ -51,5 +51,6 @@ h4.panel-title {
 @media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
     .post-title-main {
         margin-right: 0px;
+        margin-top: 25px;
     }
 }

--- a/docs/css/pageElements/headers.css
+++ b/docs/css/pageElements/headers.css
@@ -47,3 +47,9 @@ h4.panel-title {
     margin-top: 0px;
     margin-bottom: 0px;
 }   
+
+@media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
+    .post-title-main {
+        margin-right: 0px;
+    }
+}


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
At mobile-view changeover, the margin-right on the page title is removed
Also that the changeover, a top margin is added to space the title from the TOC