### PR TITLE
fix: title margin breaks title buttons

### DIFF
--- a/docs/css/pageElements/headers.css
+++ b/docs/css/pageElements/headers.css
@@ -52,6 +52,18 @@ h4.panel-title {
 @media only screen and (max-width: 991px), only screen and (max-device-width: 991px) {
     .post-title-main {
         margin-right: 0px;
-        margin-top: 25px;
+        width: 100% 
+    }
+
+    .post-header {
+        margin-top: 27px;
+    }
+    
+    .title-buttons {
+        margin-top: 7px !important
+    }
+
+    .githubEditButton:first-child {
+        margin-left: 0px
     }
 }


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
- Top margin now defined on post-header class
- Force title buttons to new line in mobile view
- Remove left margin when github edit button is only button present

closes #115 