### PR TITLE
fix: Visual contribution bubbles in print mode

### DIFF
--- a/docs/css/print.css
+++ b/docs/css/print.css
@@ -64,4 +64,12 @@
     .noPrinterView {
         display: none;
     }
+
+    .sc-filled {
+        color: black
+    }
+    
+    .sc-empty {
+        display: none;
+    }
 }


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
Right now, when printed in black and white, both colours of contribution bubbles become black, meaning the purpose of having that section is lost. Now, black bubbles are set to `display: none` so they display almost correctly