### PR TITLE
fix: labeler rules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,6 @@
 - docs/_tooltips/*
 - docs/_data/*
 - docs/_fonts/*
-- docs/
   
 'backend: Meta':
 - .github/**/*


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
- Don't apply styling label to anything directly under `docs/`