### PR TITLE
fix: keyboard overlay clipped by screen

### DIFF
--- a/docs/css/pageElements/console_buttons.css
+++ b/docs/css/pageElements/console_buttons.css
@@ -61,6 +61,7 @@
     height: max-content;
     padding: 15px;
     overflow: auto;
+    box-shadow: 1px 1px rgba(0,0,0,0.5);
 }
 
 .display-button-softkey > .keyboard-svg-graphic,

--- a/docs/js/modules/button-overlay.js
+++ b/docs/js/modules/button-overlay.js
@@ -1,6 +1,7 @@
 import {validReqArgs} from "./uriArgs.js"
 
 const KEYBOARD_SVG_FADE_TIME = 150;
+const EDGE_BUFFER = 5;
 
 $( document ).ready(function() {
     if (document.getElementsByClassName("display-button-softkey").length > 0
@@ -121,6 +122,22 @@ function ViewDoWork(View, keyID, revertToSoftkey) {
             }
         }
     }
+
+    const smallScreenCorrection = View.scrollWidth >= window.screen.width - 1
+
+    if (smallScreenCorrection) {
+        View.style.left = `${View.offsetLeft - (View.getBoundingClientRect().right - window.screen.width)}px`
+    } else {
+        if (View.getBoundingClientRect().right > window.screen.width ) {
+            View.style.left = `${View.offsetLeft - (View.getBoundingClientRect().right - window.screen.width) - EDGE_BUFFER}px`
+        } 
+    
+        if (View.getBoundingClientRect().left < 0) {
+            View.style.left = `${View.offsetLeft - (View.getBoundingClientRect().left) + EDGE_BUFFER}px`
+        } 
+    }
+
+
 
     if (View.style.opacity !== 100) {
         View.style.transition = `opacity ${KEYBOARD_SVG_FADE_TIME}ms linear`;


### PR DESCRIPTION
## Describe Your Changes
- I modified existing content

## Provide any additional information:
Overlay is shifted to the screen border if it would overlap. If the screen is so small the overlay would take up the entire width, it is instead centered.

closes #114 